### PR TITLE
Retain circle and connection/join fixes

### DIFF
--- a/PhoenixClient.podspec
+++ b/PhoenixClient.podspec
@@ -27,5 +27,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes/**/*'
-  s.dependency "SocketRocket", "0.3.1-beta2"
+  s.dependency "SocketRocket", "0.4.2"
 end

--- a/Pod/Classes/PhxChannel.h
+++ b/Pod/Classes/PhxChannel.h
@@ -23,8 +23,8 @@
 
 @interface PhxChannel : NSObject
 
-@property (nonatomic) id<PhxChannelDelegate> delegate;
-@property (nonatomic, retain) PhxSocket* socket;
+@property (nonatomic, weak) id<PhxChannelDelegate> delegate;
+@property (nonatomic, weak) PhxSocket* socket;
 @property (nonatomic, readonly) ChannelState state;
 @property (nonatomic, retain) NSString* topic;
 @property (nonatomic, retain) NSDictionary *params;
@@ -35,7 +35,6 @@
 
 - (PhxPush*)join;
 - (void)leave;
-- (BOOL)canSendPush;
 
 - (void)onEvent:(NSString*)event callback:(OnReceive)callback;
 - (void)offEvent:(NSString*)event;

--- a/Pod/Classes/PhxPush.m
+++ b/Pod/Classes/PhxPush.m
@@ -13,7 +13,7 @@
 
 @interface PhxPush ()
 
-@property (nonatomic, retain) PhxChannel *channel;
+@property (nonatomic, weak) PhxChannel *channel;
 @property (nonatomic, retain) NSString *event;
 @property (nonatomic, retain) NSString *refEvent;
 @property (nonatomic, retain) NSDictionary *payload;
@@ -56,11 +56,12 @@
     self.receivedResp = nil;
     self.sent = NO;
     
+    __weak typeof(self) weakSelf = self;
     [self.channel onEvent:self.refEvent callback:^(id message, id ref) {
-        self.receivedResp = message;
-        [self matchReceive:message];
-        [self cancelRefEvent];
-        [self cancelAfter];
+        weakSelf.receivedResp = message;
+        [weakSelf matchReceive:message];
+        [weakSelf cancelRefEvent];
+        [weakSelf cancelAfter];
     }];
     [self startAfter];
     self.sent = YES;
@@ -101,9 +102,10 @@
     if (!self.afterHook) {
         return;
     }
+    __weak typeof(self) weakSelf = self;
     After callback = ^() {
-        [self cancelRefEvent];
-        self.afterHook();
+        [weakSelf cancelRefEvent];
+        weakSelf.afterHook();
     };
     self.afterTimer = [NSTimer scheduledTimerWithTimeInterval:self.afterInterval target:self selector:@selector(afterTimerFire:) userInfo:callback repeats:NO];
 }

--- a/Pod/Classes/PhxSocket.h
+++ b/Pod/Classes/PhxSocket.h
@@ -21,7 +21,7 @@
 
 @interface PhxSocket : NSObject
 
-@property (nonatomic) id<PhxSocketDelegate> delegate;
+@property (nonatomic, weak) id<PhxSocketDelegate> delegate;
 @property (nonatomic, readwrite) BOOL reconnectOnError;
 
 - (id)initWithURL:(NSURL*)url;

--- a/Pod/Classes/PhxTypes.h
+++ b/Pod/Classes/PhxTypes.h
@@ -17,8 +17,7 @@ typedef enum {
 typedef enum {
     ChannelClosed,
     ChannelErrored,
-    ChannelJoined,
-    ChannelJoining
+    ChannelJoined
 } ChannelState;
 
 typedef void (^OnOpen)(void);


### PR DESCRIPTION
There are few changes that fix following:
1. Creating many rejoin tasks by timer.<br/><br/>
   After losing connection there were created many parallel rejoin tasks: on connection error and on each fairing of rejoin timer.<br/><br/>
   Fixes: rejoin timer was removed, `rejoin` is instead calling now on socket open. If `reconnectOnErrors` is off it is possible to call `rejoin` manually. Otherwise `rejoin` will be faired on success reconnection.<br/><br/>
2. Manual disconnection.<br/><br/>
   Trying to disconnect manually after losing connection reconnection timer was still working.<br/><br/>
   Fixes: invalidate reconnection timer on calling `disconnect`<br/><br/>
3. Retain circle.<br/><br/>
   After disconnecting and nullifying link to `PhxSocket` the socket instance continued living. So it was not released by GC. This caused many uncontrolled connections/joins and little memory leaks during app's life circle.<br/><br/>
   Fixes: weak links to delegates, to socket and `self` (in blocks) in `PhxChannel`, to channel in `PhxPush`, new version of `SocketRocket` where link to `delegate` became weak too.
