### PR TITLE
Put back state ChannelJoining to avoid double joining on socket open

### DIFF
--- a/Pod/Classes/PhxChannel.m
+++ b/Pod/Classes/PhxChannel.m
@@ -79,12 +79,13 @@
 }
 
 - (void)rejoin {
-    if (self.joinedOnce && self.state != ChannelJoined) {
+    if (self.joinedOnce && self.state != ChannelJoining && self.state != ChannelJoined) {
         [self sendJoin];
     }
 }
 
 - (void)sendJoin {
+    self.state = ChannelJoining;
     self.joinPush.payload = self.params;
     [self.joinPush send];
 }

--- a/Pod/Classes/PhxTypes.h
+++ b/Pod/Classes/PhxTypes.h
@@ -17,6 +17,7 @@ typedef enum {
 typedef enum {
     ChannelClosed,
     ChannelErrored,
+    ChannelJoining,
     ChannelJoined
 } ChannelState;
 


### PR DESCRIPTION
One more little fix to avoid double-joining on opening socket.
